### PR TITLE
Implement order of creation start

### DIFF
--- a/pkg/tf-profile/parser_test.go
+++ b/pkg/tf-profile/parser_test.go
@@ -40,25 +40,25 @@ func TestFullParse(t *testing.T) {
 	log, err := Parse(s, false)
 	assert.Nil(t, err)
 
-	metrics, ok := log["time_sleep.count[9]"]
+	metrics, ok := log.resources["time_sleep.count[9]"]
 	assert.True(t, ok)
 
 	expected := ResourceMetric{
-		NumCalls:      1,
-		TotalTime:     10000,
-		CreationIndex: -1, // Not implemented
-		CreatedIndex:  12,
+		NumCalls:               1,
+		TotalTime:              10000,
+		CreationStartedIndex:   10, // Not implemented
+		CreationCompletedIndex: 12,
 	}
 	if metrics != expected {
 		t.Fatalf("Expected %v, got %v\n", expected, metrics)
 	}
 
-	metrics2 := log["time_sleep.for_each[\"a\"]"]
+	metrics2 := log.resources["time_sleep.for_each[\"a\"]"]
 	expected2 := ResourceMetric{
-		NumCalls:      1,
-		TotalTime:     1000,
-		CreationIndex: -1, // Not implemented
-		CreatedIndex:  1,
+		NumCalls:               1,
+		TotalTime:              1000,
+		CreationStartedIndex:   5, // Not implemented
+		CreationCompletedIndex: 1,
 	}
 	if metrics2 != expected2 {
 		t.Fatalf("Expected %v, got %v\n", expected2, metrics2)

--- a/pkg/tf-profile/print.go
+++ b/pkg/tf-profile/print.go
@@ -35,14 +35,14 @@ func Table(log ParsedLog, sort_spec string) error {
 
 	// Sort the resources according to the sort_spec and create rows
 	for _, r := range Sort(log, sort_spec) {
-		for resource, metric := range log {
+		for resource, metric := range log.resources {
 			if r == resource {
 				tbl.AddRow(
 					resource,
 					(metric.NumCalls),
 					(metric.TotalTime),
-					(metric.CreationIndex),
-					(metric.CreatedIndex),
+					(metric.CreationStartedIndex),
+					(metric.CreationCompletedIndex),
 				)
 				break
 			}
@@ -78,7 +78,7 @@ func Sort(log ParsedLog, sort_spec string) []string {
 
 	sort_spec_p := parseSortSpec(sort_spec)
 
-	for k, v := range log {
+	for k, v := range log.resources {
 		proxy_item_values := []float64{0, 0, 0, 0}
 
 		// With values in the order of the sort_spec, create a proxy record
@@ -91,9 +91,9 @@ func Sort(log ParsedLog, sort_spec string) []string {
 			} else if column == "tot_time" {
 				value = float64(v.TotalTime)
 			} else if column == "idx_creation" {
-				value = float64(v.CreationIndex)
+				value = float64(v.CreationStartedIndex)
 			} else if column == "idx_created" {
-				value = float64(v.CreatedIndex)
+				value = float64(v.CreationCompletedIndex)
 			}
 			if order == "desc" {
 				value = -value


### PR DESCRIPTION
This PR implements `idx_creation`: "the order in which creation started".

`> ./tf-profile --sort="idx_creation=asc" test/multiple_resources.log`

![image](https://user-images.githubusercontent.com/7376822/228954373-088dac02-2af6-4614-b677-8df6b59e1c24.png)
