### PR TITLE
Feature: add flag to disable aggregation

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -17,6 +17,7 @@ func init() {
 	rootCmd.AddCommand(graphCmd)
 	graphCmd.Flags().IntSliceVarP(&Size, "size", "s", []int{1000, 600}, "Width and height of generated image")
 	graphCmd.Flags().StringVarP(&OutFile, "out", "o", "tf-profile-graph.png", "Output file used by gnuplot")
+	graphCmd.Flags().BoolVar(&aggregate, "aggregate", true, "Agregate count[] and for_each[]")
 }
 
 var graphCmd = &cobra.Command{
@@ -27,6 +28,6 @@ var graphCmd = &cobra.Command{
 		if len(Size) != 2 || Size[0] < 0 || Size[1] < 0 {
 			return fmt.Errorf("Expected two positive integers for --size flag, got %v", Size)
 		}
-		return graph.Graph(args, Size[0], Size[1], OutFile)
+		return graph.Graph(args, Size[0], Size[1], OutFile, aggregate)
 	},
 }

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -17,7 +17,7 @@ func init() {
 	rootCmd.AddCommand(graphCmd)
 	graphCmd.Flags().IntSliceVarP(&Size, "size", "s", []int{1000, 600}, "Width and height of generated image")
 	graphCmd.Flags().StringVarP(&OutFile, "out", "o", "tf-profile-graph.png", "Output file used by gnuplot")
-	graphCmd.Flags().BoolVar(&aggregate, "aggregate", true, "Agregate count[] and for_each[]")
+	graphCmd.Flags().BoolVarP(&aggregate, "aggregate", "a", true, "Agregate count[] and for_each[]")
 }
 
 var graphCmd = &cobra.Command{

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -6,9 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	aggregate bool
+)
+
 func init() {
 	rootCmd.AddCommand(statsCmd)
 	statsCmd.Flags().BoolP("tee", "t", false, "Print logs while parsing")
+	statsCmd.Flags().BoolVar(&aggregate, "aggregate", true, "Agregate count[] and for_each[]")
 }
 
 var statsCmd = &cobra.Command{
@@ -18,6 +23,6 @@ var statsCmd = &cobra.Command{
 	a Terraform run. It prints high-level statistics on the following topics:
 	basic, time-related, creation status and modules.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return stats.Stats(args, tee)
+		return stats.Stats(args, tee, aggregate)
 	},
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -13,7 +13,7 @@ var (
 func init() {
 	rootCmd.AddCommand(statsCmd)
 	statsCmd.Flags().BoolP("tee", "t", false, "Print logs while parsing")
-	statsCmd.Flags().BoolVar(&aggregate, "aggregate", true, "Agregate count[] and for_each[]")
+	statsCmd.Flags().BoolVarP(&aggregate, "aggregate", "a", true, "Agregate count[] and for_each[]")
 }
 
 var statsCmd = &cobra.Command{

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -27,7 +27,7 @@ func init() {
 		-1,
 		"Max recursive module depth before aggregating.",
 	)
-	tableCmd.Flags().BoolVar(&aggregate, "aggregate", true, "Agregate count[] and for_each[]")
+	tableCmd.Flags().BoolVarP(&aggregate, "aggregate", "a", true, "Agregate count[] and for_each[]")
 	tableCmd.Flags().Bool("tee", false, "Print logs while parsing")
 }
 

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -27,6 +27,7 @@ func init() {
 		-1,
 		"Max recursive module depth before aggregating.",
 	)
+	tableCmd.Flags().BoolVar(&aggregate, "aggregate", true, "Agregate count[] and for_each[]")
 	tableCmd.Flags().Bool("tee", false, "Print logs while parsing")
 }
 
@@ -37,6 +38,6 @@ var tableCmd = &cobra.Command{
 	Long: `The 'table' command is used to do in-depth profiling on a resource level.
 	It will parse a log, extract metrics about all resources and show tabular output.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return table.Table(args, max_depth, tee, sort)
+		return table.Table(args, max_depth, tee, sort, aggregate)
 	},
 }

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -5,7 +5,8 @@
 **Description:** reads a Terraform log file and print high-level information about the run.
 
 **Options:**
-- -t, --tee: print logs while parsing them. Shorthand for `terraform apply | tee >(tf-profile stats)`
+- -t, --tee: print logs while parsing them. Shorthand for `terraform apply | tee >(tf-profile stats)`. Default: false
+- -a, --aggregate: enable or disable aggregation of resources created by the same `for_each` or `count` expression. Default: true
 
 **Arguments:**
 

--- a/docs/table.md
+++ b/docs/table.md
@@ -5,9 +5,11 @@
 **Description:** reads a Terraform log file and print high-level information about the run.
 
 **Options:**
-- -t, --tee: print logs while parsing them. Shorthand for `terraform apply | tee >(tf-profile stats)`
+- -t, --tee: print logs while parsing them. Shorthand for `terraform apply | tee >(tf-profile stats)`. Default: false
 - -d, --max_depth: aggregate resources nested deeper than `-d` levels into a resource that represents the module at depth `-d`. **Not implented yet**
 - -s, --sort: comma-separated key-value pairs that instruct how to sort the output table. Valid values follow the format `column1:(asc|desc),column2:(asc|desc):...`. By default, `tot_time=desc,resource=asc` is used: sort first by descending modification time, second by resource name in alphabetical order.
+- -a, --aggregate: enable or disable aggregation of resources created by the same `for_each` or `count` expression. Default: true
+
 
 **Arguments:**
 
@@ -30,7 +32,7 @@ aws_ssm_parameter.p2  1  0s        /               /             Created        
 
 The column names are lowercase and separated by underscores to allow for easy referencing in the `--sort` option. The meaning of each column is:
 
-- **resource**: Name of the resource. In case a resource is created by a `for_each` or `count` statement, resources are aggregated and individual resource identifiers are replaced by an asterisk (*).  
+- **resource**: Name of the resource. In case a resource is created by a `for_each` or `count` statement, resources are aggregated and individual resource identifiers are replaced by an asterisk (*). See the also `aggregate` option. 
 - **n**: Number of resources represented by this resource name. For regular resources, this will be 1. For resourced created with `for_each` or `count`, this number represents the number of resources created in that loop.
 - **tot_time**: Total cumulative time of all resources identified by this resource name. This is typically higher than the actual wall time, as Terraform can modify multiple resources at the same time.
 - **modify_started**: order in which resource modification _started_. This means that Terraform started by modifying the resource with `modify_started = 0`. It does not guarantee the changes to this resource finished first as well (see `modify_ended`). Resources that were already consistent with the desired state do not have this property.

--- a/pkg/tf-profile/graph/graph.go
+++ b/pkg/tf-profile/graph/graph.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/QuintenBruynseraede/tf-profile/pkg/tf-profile/readers"
 )
 
-func Graph(args []string, w int, h int, OutFile string) error {
+func Graph(args []string, w int, h int, OutFile string, aggregate bool) error {
 	var file *bufio.Scanner
 	var err error
 
@@ -32,9 +32,12 @@ func Graph(args []string, w int, h int, OutFile string) error {
 	if err != nil {
 		return err
 	}
-	tflog, err = Aggregate(tflog)
-	if err != nil {
-		return err
+
+	if aggregate {
+		tflog, err = Aggregate(tflog)
+		if err != nil {
+			return err
+		}
 	}
 
 	cleanFailedResources(tflog)

--- a/pkg/tf-profile/graph/graph_test.go
+++ b/pkg/tf-profile/graph/graph_test.go
@@ -20,14 +20,14 @@ func TestFailureParse(t *testing.T) {
 	// Sanity check: all *.log files must be graph-able
 	for _, File := range Files {
 		if strings.Contains(File.Name(), ".log") {
-			err := Graph([]string{"../../../test/" + File.Name()}, 1000, 600, "tf-profile-graph.png")
+			err := Graph([]string{"../../../test/" + File.Name()}, 1000, 600, "tf-profile-graph.png", true)
 			assert.Nil(t, err)
 		}
 	}
 
-	err = Graph([]string{"../../../test/does-not-exist"}, 1000, 600, "tf-profile-graph.png")
+	err = Graph([]string{"../../../test/does-not-exist"}, 1000, 600, "tf-profile-graph.png", true)
 	assert.NotNil(t, err)
-	err = Graph([]string{"../../../test/failures.log"}, -1, -1, "tf-profile-graph.png")
+	err = Graph([]string{"../../../test/failures.log"}, -1, -1, "tf-profile-graph.png", true)
 	assert.NotNil(t, err)
 }
 

--- a/pkg/tf-profile/stats/stats.go
+++ b/pkg/tf-profile/stats/stats.go
@@ -19,7 +19,7 @@ type Stat struct {
 	value string
 }
 
-func Stats(args []string, tee bool) error {
+func Stats(args []string, tee bool, aggregate bool) error {
 	var file *bufio.Scanner
 	var err error
 
@@ -38,9 +38,11 @@ func Stats(args []string, tee bool) error {
 		return err
 	}
 
-	tflog, err = Aggregate(tflog)
-	if err != nil {
-		return err
+	if aggregate {
+		tflog, err = Aggregate(tflog)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = PrintStats(tflog)

--- a/pkg/tf-profile/stats/stats_test.go
+++ b/pkg/tf-profile/stats/stats_test.go
@@ -88,13 +88,13 @@ func TestModuleStats(t *testing.T) {
 }
 
 func TestFullStats(t *testing.T) {
-	err := Stats([]string{"../../../test/aggregate.log"}, false)
+	err := Stats([]string{"../../../test/aggregate.log"}, false, true)
 	assert.Nil(t, err)
-	err = Stats([]string{"../../../test/multiple_resources.log"}, false)
+	err = Stats([]string{"../../../test/multiple_resources.log"}, false, true)
 	assert.Nil(t, err)
-	err = Stats([]string{"../../../test/null_resources.log"}, false)
+	err = Stats([]string{"../../../test/null_resources.log"}, false, true)
 	assert.Nil(t, err)
 
-	err = Stats([]string{"does-not-exist"}, false)
+	err = Stats([]string{"does-not-exist"}, false, true)
 	assert.NotNil(t, err)
 }

--- a/pkg/tf-profile/table/table.go
+++ b/pkg/tf-profile/table/table.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Execute the `tf-profile table` command
-func Table(args []string, max_depth int, tee bool, sort string) error {
+func Table(args []string, max_depth int, tee bool, sort string, aggregate bool) error {
 	var file *bufio.Scanner
 	var err error
 
@@ -35,9 +35,11 @@ func Table(args []string, max_depth int, tee bool, sort string) error {
 		return err
 	}
 
-	tflog, err = Aggregate(tflog)
-	if err != nil {
-		return err
+	if aggregate {
+		tflog, err = Aggregate(tflog)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = PrintTable(tflog, sort)

--- a/pkg/tf-profile/table/table_test.go
+++ b/pkg/tf-profile/table/table_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestBasicRun(t *testing.T) {
-	err := Table([]string{}, 1, true, "tot_time=asc")
+	err := Table([]string{}, 1, true, "tot_time=asc", true)
 	assert.Nil(t, err)
 }
 
 func TestFileDoesntExist(t *testing.T) {
-	err := Table([]string{"does-not-exist"}, 1, true, "tot_time=asc")
+	err := Table([]string{"does-not-exist"}, 1, true, "tot_time=asc", true)
 	assert.NotNil(t, err)
 }

--- a/tf-profile.go
+++ b/tf-profile.go
@@ -1,15 +1,5 @@
 package main
 
-// // Main entrypoint to the CLI
-// func main() {
-// 	tfprofile := tfprofile.Create()
-// 	err := tfprofile.Run(os.Args)
-
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// }
-
 import (
 	"github.com/QuintenBruynseraede/tf-profile/cmd"
 )


### PR DESCRIPTION
This PR adds support for the `--aggregate` flag for the `table`, `graph` and `stats` commands. It can be used to enable or disable the aggregation of multiple resources into one. 

Default: `aggregate = true`

Examples:
```sh
tf-profile stats --aggregate=true  # Default
tf-profile table --aggregate false  # Will keep resources names as is, i.e. foo[0], foo[1], foo[2] instead of foo[*]
tf-profile table -a false  # Short hand
``